### PR TITLE
Added temporal photon scattering notebook link

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -158,6 +158,10 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 </li>
 
 <li>
+<a href="http://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/temporal-photon-scattering.ipynb">Temporal photon scattering in quantum optical systems</a>
+</li>
+
+<li>
 <a href="http://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-5-Parametric-Amplifier.ipynb">Parametric Amplifier</a>
 </li> 
 


### PR DESCRIPTION
This PR adds a link to the demonstration notebook for a new scattering module to QuTiP to compute temporal photon scattering in an arbitrarily-specified quantum optical systems, following the theoretical framework developed in K.A. Fischer, et.al. (2017), "Scattering of Coherent Pulses from Quantum-Optical Systems" (arXiv: 1710.02875). Look for accompanying pull requests in qutip (#848), qutip-notebooks (#58), and qutip-doc.