### PR TITLE
added code of conduct

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,6 +26,7 @@
     <a href="docs/latest/changelog.html">Changelog</a> <br/>
     <a href="http://groups.google.com/group/qutip">Mailing list</a> <br/>
     <a href="https://github.com/qutip/qutip/blob/master/LICENSE.txt">Licence</a> <br/>
+    <a href="cofc.html">Code of conduct</a> <br/>
   </div>
 </div>
 

--- a/cofc.html
+++ b/cofc.html
@@ -1,0 +1,42 @@
+---
+title: Code of conduct
+---
+{% include header.html %}
+{% include navbar.html %}
+
+<div class="row">
+<div class="col-md-12">
+<h1>Code of conduct</h1>
+
+<div class="row">
+<div class="col-md-12">
+<p>
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+</p>
+<p>
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+</p>
+<p>
+Examples of unacceptable behavior by participants include:
+<ul>
+<li> The use of sexualized language or imagery</li>
+<li> Personal attacks </li>
+<li> Trolling or insulting/derogatory comments </li>
+<li> Public or private harassment </li>
+<li> Publishing other's private information, such as physical or electronic addresses, without explicit permission </li>
+<li> Other unethical or unprofessional conduct </li>
+</ul>
+</p>
+<p>
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+<p>
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+<br> <br>
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+<br><br>
+This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a> , version 1.2.0, available at <a href="https://www.contributor-covenant.org/version/1/2/0/code-of-conduct.html">https://www.contributor-covenant.org/version/1/2/0/code-of-conduct.html</a>
+
+<br><br>
+</div>
+</div>
+{% include footer.html %}


### PR DESCRIPTION
@ajgpitch I did not have access to the original Jekyll files to rebuild the whole site and test but ran the updated code of conduct HTML locally and also added a link to the same in the homepage. This works fine and can be merged.