### PR TITLE
add quantum trajectories example notebook

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -97,7 +97,9 @@ useful to have a look at these IPython notebook
 <li> <a href="http://nbviewer.ipython.org/github/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb">Stochastic master equation: Feedback control</a> </li> 
 <li> <a href="http://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/optomechanical-steadystate.ipynb">Steady state solvers: Optomechanical system</a> </li>
 <li> <a href="http://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/homodyned-Jaynes-Cummings-emission.ipynb">Homodyned Jaynes-Cummings emission</a> </li>
+<li> <a href="http://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/measures-trajectories-cats-kerr.ipynb">Monte-Carlo vs stochastic trajectories: Cat states become coherent states</a> </li>
 </ul>
+
 
 <h4>Optimal control</h4>
 <ul>


### PR DESCRIPTION
Add to examples a notebook by @fminga about quantum trajectories with Monte Carlo solver (`mcsolve`) and stochastic solver (`ssesolve`) showing how Cat states can become coherent states. 