### PR TITLE
remove image

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,26 +54,39 @@ From the classroom to the corporate office, QuTiP is used around the world to ad
 </div>
 </div>
 
+<div class="row">
+<div class="col-md-12">
+<p>
+QuTiP is open-source software for simulating the dynamics of open quantum systems.  The QuTiP library depends on the excellent <a href='http://www.numpy.org'>Numpy</a>, <a href='http://www.scipy.org'>Scipy</a>, and <a href='http://cython.org'>Cython</a> numerical packages. In addition, graphical output is provided by <a href='http://matplotlib.org'>Matplotlib</a>.  QuTiP aims to provide user-friendly and efficient numerical simulations of a wide variety of Hamiltonians, including those with arbitrary time-dependence, commonly found in a wide range of physics applications such as quantum optics, trapped ions, superconducting circuits, and quantum nanomechanical resonators. QuTiP is freely available for use and/or modification on all major platforms such as Linux, Mac OSX, and Windows<sup>*</sup>. Being free of any licensing fees, QuTiP is ideal for exploring quantum mechanics and dynamics in the classroom.
+</p>
+<p style='font-size:10px'><sup>*</sup>QuTiP is developed on Unix platforms only, and some features may not be available under Windows.</p>
+</div>
+</div>
+
 <div class="row" style='margin-top:20px'>
-<div class="col-md-4">
-<p style='margin-top:20px'>
-QuTiP is already being used at a variety of institutions around the globe, and has been downloaded hundreds of thousands of times since its initial release.  Need
-help in simulating a tricky problem? Our large community of users are gracious enough to take a moment of their time and help in tackling even the most esoteric of issues.
+<div class="col-md-6">
+<img src="images/corp_users.png">
+</div>
+<div class="col-md-5">
+<p>
+From the classroom to the corporate office, QuTiP is used around the world to advance research in quantum optics.  QuTiP is in use at nearly every single research university around the globe, government-funded research labs, and is relied upon by every major corporation focused on developing a quantum computer.
 </p>
 </div>
 </div>
 
 <div class="row" style='margin-top:20px'>
-<div class="col-md-6">
-<img src="images/qutip-downloads-2018.png">
+<div class="col-md-4">
+<p style='margin-top:20px'>
+QuTiP is already being used at a variety of institutions around the globe, and has been downloaded hundreds of thousands of times since its initial release (over 50000 times in 2018 only).  Need
+help in simulating a tricky problem? Our large community of users are gracious enough to take a moment of their time and help in tackling even the most esoteric of issues.
+</p>
 </div>
-</div>
-
 <div class="col-md-6">
 <center><h4>Distribution of the 25,473 Unique Visitors in 2016</h2><center>
 <div id='container1' style='margin-top:10px; position: relative;height: 250px;width: 400px;'></div>
 </div>
 </div>
+
 
 
 


### PR DESCRIPTION
cannot manage the downloads size image without messing up with the structure of the page. going back to previous status, only updating information about 2018 downloads, so that something after 2016 appears on the homepage. 