### PR TITLE
add conda download, fix typ0 4.5.0.dev

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,8 +4,9 @@
 <div class="panel panel-default">
   <div class="panel-heading">Latest release</div>
   <div class="panel-body">
-    <p>July 4, 2019<br />
+    <div><p>July 4, 2019<br />
         4.4.0 -
+        <a href="http://qutip.org/docs/latest/installation.html#platform-independent-installation">conda and pip (recommended)</a></div>
         <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.4.0.tar.gz']); void(0);" href="downloads/4.4.0/qutip-4.4.0.tar.gz">tar.gz</a>,
         <!-- href="https://github.com/qutip/qutip/archive/v4.4.0.tar.gz" -->
         <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.4.0.zip']); void(0);" href="downloads/4.4.0/qutip-4.4.0.zip">zip</a>,
@@ -14,7 +15,7 @@
         (<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-doc-4.4.pdf']); void(0);" href="downloads/4.4.0/qutip-doc-4.4.pdf">pdf</a>)
     </p>
     <p>Development version<br />
-        4.4.0 -
+        4.5.0.dev -
         <a href="https://github.com/qutip/qutip/archive/master.zip">download</a>
     </p>
   </div>

--- a/download.html
+++ b/download.html
@@ -20,7 +20,7 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 <div class="row">
 <div class="col-md-12">
 <p>The recommended way to install QuTiP is with conda or pip, see
- <a href='http://qutip.org/docs/latest/installation.html'>the documentation for details.</a>
+ <a href='http://qutip.org/docs/latest/installation.html'>the documentation for details</a>
 .</p>
 </div>
 </div>


### PR DESCRIPTION
Make is more evident that the recommended way to download qutip is via a package manager, instead of downloading a compressed folder, as now in the homepage sidebar. 

Updated to 4.5.0.dev instead of 4.4.0 the development version text. 