### PR TITLE
Add the Stern-Gerlach tutorial notebook to the list of lectures.

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -231,6 +231,10 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 <a href="http://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-16-Gallery-of-Wigner-functions.ipynb">Gallery of Wigner functions</a>
 </li>
 
+<li>
+<a href="http://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/stern-gerlach-tutorial.ipynb">Tutorial on the Stern-Gerlach experiment</a>
+</li>
+
 </ul>
 
 </div>


### PR DESCRIPTION
Relies on https://github.com/qutip/qutip-notebooks/pull/92.