### PR TITLE
fix url link in tutorial

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -130,7 +130,7 @@ useful to have a look at these IPython notebook
 <li> <a href="http://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-spin-squeezing-noise.ipynb">Spin squeezing with noise</a> </li>
 <li> <a href="http://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-boundary-time-crystals.ipynb">Boundary time crystals</a> </li>
 <li> <a href="http://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-multiple-spin-ensembles.ipynb">Multiple spin ensembles</a> </li>
-<li> <a href="http://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-entropy-purity.ipynb">Von Neumann entropy and purity</a> </li>
+<li> <a href="http://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-entropy_purity.ipynb">Von Neumann entropy and purity</a> </li>
 
 </ul>
 </div>


### PR DESCRIPTION
Fix the link of the tutorial on Von Neuman entropy and purity for Dicke-basis density matrices in presence of homogeneous local dissipation. 