### PR TITLE
4.4 documentation link points to the appropriate page

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -50,7 +50,7 @@ title: QuTiP Documentation
 <div class="row">
 <div class="col-md-3 col-md-offset-1">
 <img src="images/online.png" />
-<a href="docs/latest/index.html">Online HTML documentation</a>
+<a href="docs/4.4/index.html">Online HTML documentation</a>
 </div>
 <div class="col-md-3 col-md-offset-1">
 <img src="images/pdf.png" />


### PR DESCRIPTION
As pointed out by @nathanshammah in the issue https://github.com/qutip/qutip.github.io/issues/121, link for 4.4 release was pointing to the latest docs. I have fixed it to point it to 4.4 release. 