### PR TITLE
Add 4.5.2 release

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,13 +4,11 @@
 <div class="panel panel-default">
   <div class="panel-heading">Latest release</div>
   <div class="panel-body">
-    <div><p>January 31, 2020<br />
-        4.5.0 -
+    <div><p>July 14, 2020<br />
+        4.5.2 -
         <a href="http://qutip.org/docs/latest/installation.html#platform-independent-installation">conda and pip (recommended)</a></div>
-        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.0.tar.gz']); void(0);" href="downloads/4.5.0/qutip-4.5.0.tar.gz">tar.gz</a>,
-        <!-- href="https://github.com/qutip/qutip/archive/v4.5.0.tar.gz" -->
-        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.0.zip']); void(0);" href="downloads/4.5.0/qutip-4.5.0.zip">zip</a>,
-        <!-- href="https://github.com/qutip/qutip/archive/v4.5.0.zip" -->
+        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.tar.gz">tar.gz</a>,
+        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.zip">zip</a>,
         <a href="docs/latest/index.html">docs</a>
         (<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-doc-4.5.pdf']); void(0);" href="downloads/4.5.0/qutip-doc-4.5.pdf">pdf</a>)
     </p>

--- a/download.html
+++ b/download.html
@@ -33,6 +33,28 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 
 <div class="row">
 <div class="col-md-5">
+<h3>Version 4.5.2 - 14 July 2020</h3>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/gz.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.tar.gz">v4.5.2.tar.gz</a>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/zip.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.zip">v4.5.2.zip</a>
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-12">
+<h2>Previous releases</h2>
+</div>
+</div>
+
+<div class="row">
+<div class="col-md-5">
 <h3>Version 4.5.0 - 31 January 2020</h3>
 </div>
 
@@ -44,12 +66,6 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 <div class="col-xs-3 col-sm-2">
 <img src="images/zip.png" />
 <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.0.zip']); void(0);" href="downloads/4.5.0/qutip-4.5.0.zip">v4.5.0.zip</a>
-</div>
-</div>
-
-<div class="row">
-<div class="col-md-12">
-<h2>Previous releases</h2>
 </div>
 </div>
 

--- a/download.html
+++ b/download.html
@@ -53,6 +53,23 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 </div>
 </div>
 
+
+<div class="row">
+<div class="col-md-5">
+<h3>Version 4.5.1 - 15 May 2020</h3>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/gz.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.1.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.1.tar.gz">v4.5.1.tar.gz</a>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/zip.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.1.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.1.zip">v4.5.1.zip</a>
+</div>
+</div>
+
 <div class="row">
 <div class="col-md-5">
 <h3>Version 4.5.0 - 31 January 2020</h3>


### PR DESCRIPTION
I linked directly to the GitHub-hosted assets for the source code release, rather than adding a binary file to the `git` repo (generally not a great idea).