### PR TITLE
Add 4.5.3 release

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,11 +4,11 @@
 <div class="panel panel-default">
   <div class="panel-heading">Latest release</div>
   <div class="panel-body">
-    <div><p>July 14, 2020<br />
-        4.5.2 -
+    <div><p>February 19, 2021<br />
+        4.5.3 -
         <a href="http://qutip.org/docs/latest/installation.html#platform-independent-installation">conda and pip (recommended)</a></div>
-        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.tar.gz">tar.gz</a>,
-        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.zip">zip</a>,
+        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.3.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.3.tar.gz">tar.gz</a>,
+        <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.3.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.3.zip">zip</a>,
         <a href="docs/latest/index.html">docs</a>
         (<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-doc-4.5.pdf']); void(0);" href="downloads/4.5.0/qutip-doc-4.5.pdf">pdf</a>)
     </p>

--- a/download.html
+++ b/download.html
@@ -33,6 +33,30 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 
 <div class="row">
 <div class="col-md-5">
+<h3>Version 4.5.3 - 19 February 2021</h3>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/gz.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.3.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.3.tar.gz">v4.5.3.tar.gz</a>
+</div>
+
+<div class="col-xs-3 col-sm-2">
+<img src="images/zip.png" />
+<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.3.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.3.zip">v4.5.3.zip</a>
+</div>
+</div>
+
+
+<div class="row">
+<div class="col-md-12">
+<h2>Previous releases</h2>
+</div>
+</div>
+
+
+<div class="row">
+<div class="col-md-5">
 <h3>Version 4.5.2 - 14 July 2020</h3>
 </div>
 
@@ -46,13 +70,6 @@ QuTiP has been developed over seven years by volunteers working in their spare t
 <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.5.2.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.5.2.zip">v4.5.2.zip</a>
 </div>
 </div>
-
-<div class="row">
-<div class="col-md-12">
-<h2>Previous releases</h2>
-</div>
-</div>
-
 
 <div class="row">
 <div class="col-md-5">


### PR DESCRIPTION
A related question, I notice that the download link is rarely updated promptly when a new release is out.
Isn't it better to setup a webhook to update the latest release link in the landing page to whatever the latest release is on github?