### PR TITLE
Remove additional row-ending div tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,6 @@ title: Quantum Toolbox in Python
 </div>
 
 </div>
-</div>
-</div>
 
 <script>
     var lng = navigator.language;


### PR DESCRIPTION
Turns out some extra closing divs got added in #136, and the starting ones didn't.  End result is that the "CSS table" structure got closed with only the alert boxes in it, pushing everything else down below.

Fix #141.