### PR TITLE
Add a link to the single photon interference tutorial.

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -277,6 +277,10 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/stern-gerlach-tutorial.ipynb">Tutorial on the Stern-Gerlach experiment</a>
 </li>
 
+<li>
+<a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/single-photon-interference-example.ipynb">Tutorial on Single Photon Interference</a>
+</li>
+
 </ul>
 
 </div>


### PR DESCRIPTION
Add a link to the single photon interference tutorial contributed by @Amelie-og and her Maastricht Science Programme project team.

NBViewer is still catching up with the state of the qutip-notebook repository, but in the mean time you can see a preview of the notebook here -- https://nbviewer.org/github/Amelie-og/qutip-notebooks/blob/master/examples/single-photon-interference-example.ipynb