### PR TITLE
Replace nbviewer.ipython.org with nbviewer.org on tutorials page.

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -61,56 +61,56 @@ useful to have a look at these IPython notebook
 <div class="col-md-6">
 <h4 id="python-introduction">Python Introduction</h4>
 <ul>
-<li><a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/python/Beginning_Python.ipynb">Quick introduction to Python</a></li>
-<li><a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/python/NumPy_Array_Basics.ipynb">Overview of NumPy Arrays</a></li>
-<li><a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/python/Matplotlib_Plotting.ipynb">Brief introduction to Matplotlib</a></li>
+<li><a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/python/Beginning_Python.ipynb">Quick introduction to Python</a></li>
+<li><a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/python/NumPy_Array_Basics.ipynb">Overview of NumPy Arrays</a></li>
+<li><a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/python/Matplotlib_Plotting.ipynb">Brief introduction to Matplotlib</a></li>
 </ul>
 <p>For a more in depth discussion see: <a href='https://github.com/jrjohansson/scientific-python-lectures'>Lectures on scientific computing with Python</a>.</p>
 
 <h4 id="basics">Basics</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-0-Introduction-to-QuTiP.ipynb">Introduction to QuTiP</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/eseries.ipynb">Exponential series</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/ultrastrong-coupling-groundstate.ipynb">Groundstates: Jaynes-Cummings model in the ultrastrong coupling regime</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/superop-contract.ipynb">Superoperators, Pauli basis and channel contraction</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-0-Introduction-to-QuTiP.ipynb">Introduction to QuTiP</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/eseries.ipynb">Exponential series</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/ultrastrong-coupling-groundstate.ipynb">Groundstates: Jaynes-Cummings model in the ultrastrong coupling regime</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/superop-contract.ipynb">Superoperators, Pauli basis and channel contraction</a> </li>
 </ul>
 
 <h4 id="visualizations">Visualization</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/visualization-exposition.ipynb">Visualization demos</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/energy-levels.ipynb">Energy-level diagrams</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/bloch-sphere-animation.ipynb">Bloch-sphere animation</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/visualization-exposition.ipynb">Visualization demos</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/energy-levels.ipynb">Energy-level diagrams</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/bloch-sphere-animation.ipynb">Bloch-sphere animation</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/bloch_sphere_with_colorbar.ipynb">Bloch sphere with colorbar</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/JC-model-wigner-function.ipynb">Wigner functions</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/pseudo-probability-functions.ipynb">Pseudo-probability functions</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-process-tomography.ipynb">Process tomography</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qubism-and-schmidt-plots.ipynb">Qubism visualizations</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/JC-model-wigner-function.ipynb">Wigner functions</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/pseudo-probability-functions.ipynb">Pseudo-probability functions</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-process-tomography.ipynb">Process tomography</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qubism-and-schmidt-plots.ipynb">Qubism visualizations</a> </li>
 </ul>
 
 <h4 id="quantum-information-processing">Quantum information processing</h4>
 <p>This section requires an additional package <a href='https://github.com/qutip/qutip-qip'>qutip-qip</a>.</p>
 <h5 id="quantum-circuits">Quantum circuits</h5>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-gates.ipynb">Quantum gates and circuits</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-toffoli-cnot.ipynb">Toffoli gate to CNOT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qasm.ipynb">Importing and exporting QASM circuits</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/teleportation.ipynb">Quantum teleportation</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/quantum-gates.ipynb">Quantum gates and circuits</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-toffoli-cnot.ipynb">Toffoli gate to CNOT</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qasm.ipynb">Importing and exporting QASM circuits</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/teleportation.ipynb">Quantum teleportation</a> </li>
 </ul>
 
 <h5 id="nisq">Pulse-level circuit simulation</h5>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-processor-DJ-algorithm.ipynb">Simulating the Deutsch–Jozsa algorithm with noise</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-customize-device.ipynb">Customizing the pulse-level simulation</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-scheduler.ipynb">The pulse scheduler</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-relaxation-measurement-with-the-idling-gate.ipynb">Measuring the relaxation time</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-10-qubit-QFT-algorithm.ipynb">Simulating a 10-qubit QFT algorithm</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-randomized-benchmarking.ipynb">Simulating randomized benchmarking</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qip-optpulseprocessor.ipynb">Optimal pulse processor</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-processor-DJ-algorithm.ipynb">Simulating the Deutsch–Jozsa algorithm with noise</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-customize-device.ipynb">Customizing the pulse-level simulation</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-scheduler.ipynb">The pulse scheduler</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-relaxation-measurement-with-the-idling-gate.ipynb">Measuring the relaxation time</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-10-qubit-QFT-algorithm.ipynb">Simulating a 10-qubit QFT algorithm</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-randomized-benchmarking.ipynb">Simulating randomized benchmarking</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qip-optpulseprocessor.ipynb">Optimal pulse processor</a> </li>
 </ul>
 
 <h4 id="piqs">Permutational invariant Lindblad dynamics</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-overview.ipynb">Overview</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-overview.ipynb">Overview</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-superradiant-light-emission.ipynb">Superradiant light emission</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-steadystate-superradiance.ipynb">Steady state superradiance</a> </li>
 <li> <a href="https://nbviewer.jupyter.org/github/qutip/qutip-notebooks/blob/master/examples/piqs-open-dicke-model.ipynb">Open Dicke model</a> </li>
@@ -126,51 +126,51 @@ useful to have a look at these IPython notebook
 
 <h4 id="time-evolution">Time evolution</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb">The <code>QobjEvo</code> class for optimised time-dependence</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/qubit-dynamics.ipynb">Master equation solver: Qubit dynamics</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/rabi-oscillations.ipynb">Master equation solver: Vacuum Rabi oscillations</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/spin-chain.ipynb">Master equation solver: Spin chain</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/trilinear.ipynb">Monte-Carlo solver: Trilinear oscillators</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/photon_birth_death.ipynb">Monte-Carlo solver: Birth and death of photons in a cavity</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/brmesolve.ipynb">Bloch-Redfield master equation solver</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/brmesolve-time-dependent-Liouvillian.ipynb">Time-dependent Bloch-Redfield quantum dot</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/floquet-dynamics.ipynb">Floquet formalism</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/quasi-steadystate-driven-system.ipynb">Quasi-steadystate of time-dependent (periodic) systems</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/landau-zener.ipynb">Time-dependent master equation: Landau-Zener transitions</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/landau-zener-stuckelberg.ipynb">Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-heterodyne.ipynb">Stochastic master equation: Heterodyne detection</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-inefficient-detection.ipynb">Stochastic master equation: Inefficient detection</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-jc-photocurrent.ipynb">Stochastic master equation: Jaynes-Cummings model with photocurrent detection</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb">Stochastic master equation: Feedback control</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/optomechanical-steadystate.ipynb">Steady state solvers: Optomechanical system</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/homodyned-Jaynes-Cummings-emission.ipynb">Homodyned Jaynes-Cummings emission</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/measures-trajectories-cats-kerr.ipynb">Monte-Carlo vs stochastic trajectories: Cat states become coherent states</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qobjevo.ipynb">The <code>QobjEvo</code> class for optimised time-dependence</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/qubit-dynamics.ipynb">Master equation solver: Qubit dynamics</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/rabi-oscillations.ipynb">Master equation solver: Vacuum Rabi oscillations</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/spin-chain.ipynb">Master equation solver: Spin chain</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/trilinear.ipynb">Monte-Carlo solver: Trilinear oscillators</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/photon_birth_death.ipynb">Monte-Carlo solver: Birth and death of photons in a cavity</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/brmesolve.ipynb">Bloch-Redfield master equation solver</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/brmesolve-time-dependent-Liouvillian.ipynb">Time-dependent Bloch-Redfield quantum dot</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/floquet-dynamics.ipynb">Floquet formalism</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/quasi-steadystate-driven-system.ipynb">Quasi-steadystate of time-dependent (periodic) systems</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/landau-zener.ipynb">Time-dependent master equation: Landau-Zener transitions</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/landau-zener-stuckelberg.ipynb">Time-dependent master equation: Landau-Zener-Stuckelberg inteferometry</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-heterodyne.ipynb">Stochastic master equation: Heterodyne detection</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-inefficient-detection.ipynb">Stochastic master equation: Inefficient detection</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/smesolve-jc-photocurrent.ipynb">Stochastic master equation: Jaynes-Cummings model with photocurrent detection</a> </li>
+<li> <a href="https://nbviewer.org/github/jrjohansson/reproduced-papers/blob/master/Reproduce-SIAM-JCO-46-445-2007-Mirrahimi.ipynb">Stochastic master equation: Feedback control</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/optomechanical-steadystate.ipynb">Steady state solvers: Optomechanical system</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/homodyned-Jaynes-Cummings-emission.ipynb">Homodyned Jaynes-Cummings emission</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/measures-trajectories-cats-kerr.ipynb">Monte-Carlo vs stochastic trajectories: Cat states become coherent states</a> </li>
 </ul>
 
 
 <h4 id="optimal-control">Optimal control</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/optimal-control-overview.ipynb">Overview</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Hadamard.ipynb">Hadamard</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-QFT.ipynb">QFT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Lindbladian.ipynb">Lindbladian</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-symplectic.ipynb">Symplectic</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-QFT.ipynb">QFT (CRAB)</a> </li>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-2qubitInerac.ipynb">State to state (CRAB)</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-cnot.ipynb">CNOT</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-iswap.ipynb">iSWAP</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-single-qubit-rotation.ipynb">Single-qubit rotation</a> </li>
-<li> <a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-toffoli.ipynb">Toffoli gate</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/optimal-control-overview.ipynb">Overview</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Hadamard.ipynb">Hadamard</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-QFT.ipynb">QFT</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-Lindbladian.ipynb">Lindbladian</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-pulseoptim-symplectic.ipynb">Symplectic</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-QFT.ipynb">QFT (CRAB)</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/control-pulseoptim-CRAB-2qubitInerac.ipynb">State to state (CRAB)</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-cnot.ipynb">CNOT</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-iswap.ipynb">iSWAP</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-single-qubit-rotation.ipynb">Single-qubit rotation</a> </li>
+<li> <a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/control-grape-toffoli.ipynb">Toffoli gate</a> </li>
 </ul>
 
 <h4 id="tomography">Tomography</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/tomography-iMLE-photon-counting.ipynb">Density matrix estimation with iterative maximum likelihood estimation</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/tomography-iMLE-photon-counting.ipynb">Density matrix estimation with iterative maximum likelihood estimation</a> </li>
 </ul>
 
 <h4 id="heom">Hierarchical Equations of Motion</h4>
 <ul>
-<li> <a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/heom/heom-index.ipynb">Examples for solving the dynamics of systems coupled to bosonic and fermoinic baths using the Hierarchical Equations of Motion</a> </li>
+<li> <a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/heom/heom-index.ipynb">Examples for solving the dynamics of systems coupled to bosonic and fermoinic baths using the Hierarchical Equations of Motion</a> </li>
 </ul>
 
 </div>
@@ -185,99 +185,99 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 
 <ul>
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-1-Jaynes-Cumming-model.ipynb">Jaynes-Cummings model</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-1-Jaynes-Cumming-model.ipynb">Jaynes-Cummings model</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-2A-Cavity-Qubit-Gates.ipynb">Cavity-qubit gates</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-2A-Cavity-Qubit-Gates.ipynb">Cavity-qubit gates</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-2B-Single-Atom-Lasing.ipynb">Single-atom lasing</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-2B-Single-Atom-Lasing.ipynb">Single-atom lasing</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-3A-Dicke-model.ipynb">Dicke model</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-3A-Dicke-model.ipynb">Dicke model</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-3B-Jaynes-Cumming-model-with-ultrastrong-coupling.ipynb">Jaynes-Cummings with ultrastrong coupling</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-3B-Jaynes-Cumming-model-with-ultrastrong-coupling.ipynb">Jaynes-Cummings with ultrastrong coupling</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-4-Correlation-Functions.ipynb">Correlation Functions</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-4-Correlation-Functions.ipynb">Correlation Functions</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/pulse-wise-second-order-coherence-g2.ipynb">Pulse-wise second-order coherence, g<sup>(2)</sup>[0]</a>
+<a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/pulse-wise-second-order-coherence-g2.ipynb">Pulse-wise second-order coherence, g<sup>(2)</sup>[0]</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/pulse-wise-two-photon-interference.ipynb">Pulse-wise two-photon interference</a>
+<a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/pulse-wise-two-photon-interference.ipynb">Pulse-wise two-photon interference</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/temporal-photon-scattering.ipynb">Temporal photon scattering in quantum optical systems</a>
+<a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/temporal-photon-scattering.ipynb">Temporal photon scattering in quantum optical systems</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/photon-emission.ipynb">Particle emission from a photon cascade</a>
+<a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/photon-emission.ipynb">Particle emission from a photon cascade</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-5-Parametric-Amplifier.ipynb">Parametric Amplifier</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-5-Parametric-Amplifier.ipynb">Parametric Amplifier</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-6-Quantum-Monte-Carlo-Trajectories.ipynb">Quantum Monte-Carlo trajectories</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-6-Quantum-Monte-Carlo-Trajectories.ipynb">Quantum Monte-Carlo trajectories</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-7-iSWAP-gate.ipynb">iSWAP gate</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-7-iSWAP-gate.ipynb">iSWAP gate</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-8-Adiabatic-quantum-computing.ipynb">Adiabatic quantum computing</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-8-Adiabatic-quantum-computing.ipynb">Adiabatic quantum computing</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-9-Squeezed-states-of-harmonic-oscillator.ipynb">Squeezed states of an harmonic oscillator</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-9-Squeezed-states-of-harmonic-oscillator.ipynb">Squeezed states of an harmonic oscillator</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-10-cQED-dispersive-regime.ipynb">cQED in the dispersive regime</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-10-cQED-dispersive-regime.ipynb">cQED in the dispersive regime</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-11-Charge-Qubits.ipynb">Superconducting charge qubits</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-11-Charge-Qubits.ipynb">Superconducting charge qubits</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-12-Decay-into-a-squeezed-vacuum-field.ipynb">Decay into a squeezed vacuum field</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-12-Decay-into-a-squeezed-vacuum-field.ipynb">Decay into a squeezed vacuum field</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-13-Resonance-flourescence.ipynb">Resonance fluorescence</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-13-Resonance-flourescence.ipynb">Resonance fluorescence</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-14-Kerr-nonlinearities.ipynb">Kerr nonlinearities</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-14-Kerr-nonlinearities.ipynb">Kerr nonlinearities</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-15-Nonclassically-driven-atoms.ipynb">Nonclassically driven atoms</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-15-Nonclassically-driven-atoms.ipynb">Nonclassically driven atoms</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-16-Gallery-of-Wigner-functions.ipynb">Gallery of Wigner functions</a>
+<a href="https://nbviewer.org/urls/raw.github.com/jrjohansson/qutip-lectures/master/Lecture-16-Gallery-of-Wigner-functions.ipynb">Gallery of Wigner functions</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/stern-gerlach-tutorial.ipynb">Tutorial on the Stern-Gerlach experiment</a>
+<a href="https://nbviewer.org/urls/raw.github.com/qutip/qutip-notebooks/master/examples/stern-gerlach-tutorial.ipynb">Tutorial on the Stern-Gerlach experiment</a>
 </li>
 
 <li>
-<a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/blob/master/examples/single-photon-interference-example.ipynb">Tutorial on Single Photon Interference</a>
+<a href="https://nbviewer.org/github/qutip/qutip-notebooks/blob/master/examples/single-photon-interference-example.ipynb">Tutorial on Single Photon Interference</a>
 </li>
 
 </ul>
@@ -290,7 +290,7 @@ topics and analyze them numerically using QuTiP (some more detailed than others)
 <h3 id="development-nbs">Development notebooks</h3>
 <p>A collection of more technical development notebooks, which often focus on
 testing and benchmarking various features of QuTiP, is available
-<a href="https://nbviewer.ipython.org/github/qutip/qutip-notebooks/tree/master/development/">here</a>.
+<a href="https://nbviewer.org/github/qutip/qutip-notebooks/tree/master/development/">here</a>.
 </p>
 
 </div>


### PR DESCRIPTION
The nbviewer website appears to have broken its old nbviewer.ipython.org URLs, breaking all of the tutorial notebook links. Various links in documentation are broken too, but this PR only fixes the most urgent issue, i.e. the broken tutorial links.