### PR TITLE
Convert includes relative URLs to site relative URLs.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,11 +4,11 @@
 
 </div> <!-- container -->
 
-<script src="js/jquery.js"></script>
-<script src="js/bootstrap.min.js"></script>
+<script src="/js/jquery.js"></script>
+<script src="/js/bootstrap.min.js"></script>
 <script src='https://d3js.org/d3.v3.min.js'></script>
 <script src='https://d3js.org/topojson.v1.min.js'></script>
-<script src='js/datamaps.world.min.js'></script>
-<script src='js/map.js'></script>
+<script src='/js/datamaps.world.min.js'></script>
+<script src='/js/map.js'></script>
 </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,15 +5,15 @@
     content="_8nZ7KJx54y7NEnE3tvEmjGutx6mtTMsanWXgnXxjaE" />
     <meta charset="utf-8">
     <title>QuTiP - Quantum Toolbox in Python</title>
-    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="P.D. Nation & J.R. Johansson">
 
-    <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="/css/bootstrap.css" rel="stylesheet">
     <style> body { padding-top: 0px; } .footer { padding-top: 50px; } </style>
     <link href='https://fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>
-    <link href="css/site.css" rel="stylesheet">
+    <link href="/css/site.css" rel="stylesheet">
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7GD9QRNR6E"></script>
     <script>
@@ -36,7 +36,7 @@
 
 <div class="row" style="margin: 20px;">
 <div class="col-md-4">
-<img src="images/logo.png" height="125px">
+<img src="/images/logo.png" height="125px">
 </div>
 
 <div class="col-md-6">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,32 +6,31 @@
     <span class="icon-bar"></span>
     <span class="icon-bar"></span>
   </button>
-  <a class="navbar-brand" href="index.html">QuTiP</a>
+  <a class="navbar-brand" href="/index.html">QuTiP</a>
 </div>
 <div class="navbar-collapse collapse">
   <ul class="nav navbar-nav">
-    <li><a href="news.html">News</a></li>
-    <li><a href="features.html">Features</a></li>
-    <li><a href="download.html">Download</a></li>
-    <li><a href="citing.html">Citing</a></li>
+    <li><a href="/news.html">News</a></li>
+    <li><a href="/features.html">Features</a></li>
+    <li><a href="/download.html">Download</a></li>
+    <li><a href="/citing.html">Citing</a></li>
     <li class="dropdown">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation<b class="caret"></b></a>
       <ul class="dropdown-menu">
-        <li><a href="documentation.html">Users Guide</a></li>
-        <li><a href="tutorials.html">Tutorials</a></li>
+        <li><a href="/documentation.html">Users Guide</a></li>
+        <li><a href="/tutorials.html">Tutorials</a></li>
       </ul>
     </li>
     <li class="dropdown">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Users<b class="caret"></b></a>
       <ul class="dropdown-menu">
-        <li><a href="users.html">Papers Using QuTiP</a></li>
-        <li><a href="jobs.html">Job Announcements</a></li>
+        <li><a href="/users.html">Papers Using QuTiP</a></li>
+        <li><a href="/jobs.html">Job Announcements</a></li>
       </ul>
     </li>
-    <li><a href="devs.html">Devs</a></li>
+    <li><a href="/devs.html">Devs</a></li>
     <li><a href="https://groups.google.com/group/qutip">Help Group</a></li>
     <li><a href="https://www.github.com/qutip">Github</a></li>
   </ul>
 </div>
 </div>
-

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,7 +9,7 @@
         <a href="https://qutip.org/docs/latest/installation.html#platform-independent-installation">conda and pip (recommended)</a>
         <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.7.0.tar.gz']); void(0);" href="https://github.com/qutip/qutip/archive/v4.7.0.tar.gz">tar.gz</a>,
         <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-4.7.0.zip']); void(0);" href="https://github.com/qutip/qutip/archive/v4.7.0.zip">zip</a>,
-        <a href="docs/latest/index.html">docs</a>
+        <a href="/docs/latest/index.html">docs</a>
         (<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-doc-4.7.pdf']); void(0);" href="downloads/4.7.0/qutip-doc-4.7.pdf">pdf</a>)
     </p>
     <p>Development version<br />
@@ -23,12 +23,12 @@
 <div class="panel panel-default">
   <div class="panel-heading">About QuTiP</div>
   <div class="panel-body">
-    <a href="docs/latest/installation.html">Installation</a> <br/>
+    <a href="/docs/latest/installation.html">Installation</a> <br/>
     <a href="https://www.github.com/qutip/qutip/issues">Issue tracker</a> <br/>
-    <a href="docs/latest/changelog.html">Changelog</a> <br/>
+    <a href="/docs/latest/changelog.html">Changelog</a> <br/>
     <a href="https://groups.google.com/group/qutip">Mailing list</a> <br/>
     <a href="https://github.com/qutip/qutip/blob/master/LICENSE.txt">License</a> <br/>
-    <a href="cofc.html">Code of conduct</a> <br/>
+    <a href="/cofc.html">Code of conduct</a> <br/>
   </div>
 </div>
 
@@ -58,7 +58,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">Affiliated to</div>
   <div class="panel-body">
-    <a href="https://numfocus.org/"><img src="images/numfocus.png"></a>
+    <a href="https://numfocus.org/"><img src="/images/numfocus.png"></a>
   </div>
 </div>
 


### PR DESCRIPTION
So that they work in pages in sub-folders (e.g. the upcoming qutip.org/qutip-tutorials/ folder).

Addresses https://github.com/qutip/qutip-tutorials/issues/53.