### PR TITLE
Removed broken links in documentation

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -222,30 +222,8 @@ title: QuTiP Documentation
 
 <div class="row">
 <div class="col-md-3 col-md-offset-1">
-<img src="images/online.png" />
-<a href="docs/2.2.0/index.html">Online HTML documentation</a>
-</div>
-<div class="col-md-3 col-md-offset-1">
 <img src="images/pdf.png" />
 <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-2.2.0-DOC.pdf']); void(0);" href="downloads/2.2.0/QuTiP-2.2.0-DOC.pdf">PDF documentation</a>
-</div>
-</div>
-
-
-<div class="row">
-<div class="col-md-12 col-md-offset-1">
-<h3>Version 2.1.0</h3>
-</div>
-</div>
-
-<div class="row">
-<div class="col-md-3 col-md-offset-1">
-<img src="images/online.png" />
-<a href="https://qutip.googlecode.com/svn/doc/2.1.0/html/index.html">Online HTML documentation</a>
-</div>
-<div class="col-md-3 col-md-offset-1">
-<img src="images/pdf.png" />
-<a onclick="javascript:_gaq.push(['_trackEvent','download','qutip-doc','qutip-2.1.0-DOC.pdf']); void(0);" href="https://qutip.googlecode.com/files/QuTiP-2.1.0-DOC.pdf">PDF documentation</a>
 </div>
 </div>
 


### PR DESCRIPTION
The oldest documentation we still ahve is the pd  for v2.2.0. The html pages for that release and all documenation for 2.1.0 is missing. I removed the broken links.