### PR TITLE
Add a 404 page.

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,25 @@
+---
+title: QuTiP 404 - Page Not Found
+---
+
+<div class="jumbotron jumbotron-fluid">
+    <div class="container center-block">
+      <h1 class="display-4" style="width: 80%; margin: auto;">Oops! Page not found.</h1>
+      <img src="./images/logo.png" alt="QuTiP logo" style="opacity: 50%; width: 50%; margin: 1em auto;"/>
+    </div>
+</div>
+
+Oops! The page you requested could not be found.
+
+If you are looking for the latest QuTiP documentation, you can find it is now
+located on Read The Docs:
+
+  * [QuTiP 5 documentation](https://qutip.readthedocs.io/en/qutip-5.0.x/)
+  * [QuTiP 4 documentation](https://qutip.readthedocs.io/en/qutip-4.7.x/)
+
+Otherwise please return to the [QuTiP homepage](https://qutip.org/) or select
+a link from the navigation bar above.
+
+If you still can't find what you're looking for, please email the
+[Google Group](https://groups.google.com/group/qutip) or open an issue on
+[GitHub](https://www.github.com/qutip/qutip.github.io/issues).


### PR DESCRIPTION
When we moved our documentation to Read The Docs we removed the `latest` documentation link from our site since it is no longer the latest and thus potentially misleading.

However, this broken links used by many users to locate the documentation, so I've added a 404 page that points users to the new documentation on Read The Docs.

It's also a good idea to have a 404 page.