### PR TITLE
Update links for qutip-5.1.1

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,12 +4,12 @@
 <div class="panel panel-default">
   <div class="panel-heading">Latest releases</div>
   <div class="panel-body">
-         <strong>QuTiP 5.1.0</strong>:
+         <strong>QuTiP 5.1.1</strong>:
          <ul>
-           <li>December 19, 2024</li>
+           <li>January 15, 2025</li>
            <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/installation.html">install</a></li>
            <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/">docs</a></li>
-           <li><a href="https://github.com/qutip/qutip/releases/tag/v5.1.0">src</a></li>
+           <li><a href="https://github.com/qutip/qutip/releases/tag/v5.1.1">src</a></li>
            <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/changelog.html">changelog</a></li>
          </ul>
          <strong>QuTiP 4.7.5</strong>:

--- a/documentation.md
+++ b/documentation.md
@@ -6,7 +6,7 @@ title: QuTiP Documentation
 
 ## Latest releases
 
-### Version 5.1.0
+### Version 5.1.1
 
 <div class="row">
 <div class="col-md-3 col-md-offset-1">

--- a/download.md
+++ b/download.md
@@ -17,12 +17,12 @@ The recommended way to install QuTiP is with conda or pip, see the
 
 ## Latest releases
 
-### Verion 5.1.0 - 19 December 2024
+### Verion 5.1.1 - 15 January 2025
 
- - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.0.tar.gz']); void(0);"
-      href="https://github.com/qutip/qutip/archive/v5.1.0.tar.gz">v5.1.0.tar.gz</a>
+ - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.1.tar.gz']); void(0);"
+      href="https://github.com/qutip/qutip/archive/v5.1.1.tar.gz">v5.1.1.tar.gz</a>
  - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.0.zip']); void(0);"
-      href="https://github.com/qutip/qutip/archive/v5.1.0.zip">v5.1.0.zip</a>
+      href="https://github.com/qutip/qutip/archive/v5.1.1.zip">v5.1.1.zip</a>
 
 
 ### Version 4.7.6 - 5 April 2024
@@ -34,6 +34,13 @@ The recommended way to install QuTiP is with conda or pip, see the
 
 
 ## Recent minor releases
+
+### Verion 5.1.0 - 19 December 2024
+
+ - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.0.tar.gz']); void(0);"
+      href="https://github.com/qutip/qutip/archive/v5.1.0.tar.gz">v5.1.0.tar.gz</a>
+ - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.0.zip']); void(0);"
+      href="https://github.com/qutip/qutip/archive/v5.1.0.zip">v5.1.0.zip</a>
 
 ### Verion 5.0.4 - 3 September 2024
 


### PR DESCRIPTION
Add info about new version.

I also ran the readthedocs build for the branch `qutip-5.1.x`.
Readthedocs has build for branch and tag and for 5.1.0, we linked to the branch (as we did for 5.0), but only built the tag.
