### PR TITLE
Add qutip 5 paper to website

### DIFF
--- a/citing.md
+++ b/citing.md
@@ -6,12 +6,14 @@ title: QuTiP Citing
 
 QuTiP is developed by [several physicists](devs.html) in their spare time.
 As with anyone in academics,
-their life and death is determined entirely by citations and paper count. 
+their life and death is determined entirely by citations and paper count.
 Therefore, if you find QuTiP useful, please consider citing this project as:
 
  * J. R. Johansson, P. D. Nation, and F. Nori: "QuTiP 2: A Python framework for the dynamics of open quantum systems.", Comp. Phys. Comm. **184**, 1234 (2013), [DOI: 10.1016/j.cpc.2012.11.019](https://dx.doi.org/10.1016/j.cpc.2012.11.019).
 
  * J. R. Johansson, P. D. Nation, and F. Nori: "QuTiP: An open-source Python framework for the dynamics of open quantum systems.", Comp. Phys. Comm. **183**, 1760–1772 (2012), [DOI: 10.1016/j.cpc.2012.02.021](https://dx.doi.org/10.1016/j.cpc.2012.02.021).
+
+ * N. Lambert, E. Giguère, P. Menczel, B. Li, P. Hopf, G. Suárez, M. Gali, J. Lishman, R. Gadhvi, R. Agarwal, A. Galicia, N. Shammah, P. Nation, J. R. Johansson, S. Ahmed, S. Cross, A. Pitchford, F. Nori: "QuTiP 5: The Quantum Toolbox in Python", (2024) [DOI: 10.48550/arXiv.2412.04705](https://arxiv.org/abs/2412.04705)
 
 This will also help us secure future funding supporting the development of this software.
 


### PR DESCRIPTION
Just saw that the qutip 5 paper was not on the website.
At least, not in the news or citing page...