### PR TITLE
Fix Gem warning on page build & default layout

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,56 @@
+name: Deploy Website using Jekyll
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,11 +1,9 @@
 name: Deploy Website using Jekyll
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   
 permissions:
@@ -20,27 +18,23 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          ruby-version: '3.1'
+          bundler-cache: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3
 
   # Deployment job

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "github-pages", "~> 231", group: :jekyll_plugins
-gem "webrick", "~> 1.8"
-gem "csv", "~> 3.3"
+gem "jekyll", "~> 4.2"

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,10 @@
 title: QuTiP - Quantum Toolbox in Python
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      layout: default
 exclude:
   - "build-scripts/"
   - "CNAME"

--- a/devs.md
+++ b/devs.md
@@ -1,6 +1,5 @@
 ---
 title: QuTiP Contributors
-layout: default
 ---
 
 # QuTiP Contributors

--- a/news.html
+++ b/news.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: QuTiP News
 ---
 


### PR DESCRIPTION
This PR resolves the warning that occurs when building the webpage using GitHub Actions.
The change includes a transition from using the branch based deployment method towards using the Jekyll plugin for GitHub Actions directly.
This closely followed the best practice suggested on the [Jekyll website](https://jekyllrb.com/docs/continuous-integration/github-actions/).

As part of this change, the settings for deployment need to be changed. This needs to be done by an admin and is described [here](https://jekyllrb.com/docs/continuous-integration/github-actions/).
Essentially, by going to *Settings* > *Code and automation* > *Pages*, the *Build and Deployment* source needs to be changed to *GitHub Actions*. This needs to be done *after* merging, so that the jekyll workflow can be selected.

Let me know if we should do a meeting for this transition!

Also fixes the 404 page and default layout...