### PR TITLE
Prepare 5.2.0

### DIFF
--- a/_includes/old_sidebar.html
+++ b/_includes/old_sidebar.html
@@ -3,13 +3,13 @@
 <div class="card" style="margin-bottom: 15px;">
   <div class="card-header">Latest releases</div>
   <div class="card-body">
-         <strong>QuTiP 5.1.1</strong>:
+         <strong>QuTiP 5.2.0</strong>:
          <ul>
-           <li>January 15, 2025</li>
-           <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/installation.html">install</a></li>
-           <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/">docs</a></li>
-           <li><a href="https://github.com/qutip/qutip/releases/tag/v5.1.1">src</a></li>
-           <li><a href="https://qutip.readthedocs.io/en/qutip-5.1.x/changelog.html">changelog</a></li>
+           <li>June 6, 2025</li>
+           <li><a href="https://qutip.readthedocs.io/en/v5.2.0/installation.html">install</a></li>
+           <li><a href="https://qutip.readthedocs.io/en/v5.2.0/">docs</a></li>
+           <li><a href="https://github.com/qutip/qutip/releases/tag/v5.2.0">src</a></li>
+           <li><a href="https://qutip.readthedocs.io/en/v5.2.0/changelog.html">changelog</a></li>
          </ul>
          <strong>QuTiP 4.7.6</strong>:
          <ul>

--- a/documentation.md
+++ b/documentation.md
@@ -6,16 +6,16 @@ title: QuTiP Documentation
 
 ## Latest releases
 
-### Version 5.1.1
+### Version 5.2.0
 
 <div class="row">
 <div class="col-md-3 col-md-offset-1">
 <img src="images/rtd.png" />
-<a href="https://qutip.readthedocs.io/en/qutip-5.1.x/">Read the Docs</a>
+<a href="https://qutip.readthedocs.io/en/v5.2.0/">Read the Docs</a>
 </div>
 <div class="col-md-3 col-md-offset-1">
 <img src="images/pdf.png" />
-<a href="https://readthedocs.org/projects/qutip/downloads/pdf/qutip-5.1.x/">PDF documentation</a>
+<a href="https://readthedocs.org/projects/qutip/downloads/pdf/v5.2.0/">PDF documentation</a>
 </div>
 </div>
 

--- a/download.md
+++ b/download.md
@@ -17,10 +17,10 @@ The recommended way to install QuTiP is with conda or pip, see the
 
 ## Latest releases
 
-### Verion 5.1.1 - 15 January 2025
+### Version 5.2.0 - 6 June 2025
 
- - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.1.tar.gz']); void(0);"
-      href="https://github.com/qutip/qutip/archive/v5.1.1.tar.gz">v5.1.1.tar.gz</a>
+ - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.2.0.tar.gz']); void(0);"
+      href="https://github.com/qutip/qutip/archive/v5.2.0.tar.gz">v5.2.0.tar.gz</a>
  - <a onclick="javascript:_gaq.push(['_trackEvent','download','qutip','qutip-5.1.0.zip']); void(0);"
       href="https://github.com/qutip/qutip/archive/v5.1.1.zip">v5.1.1.zip</a>
 


### PR DESCRIPTION
Update sidebar for 5.2.0 release.

The `download` and `documentation` pages don't seems reachable anymore...
Do we still plan to use them?
If not, we should update [release_distribution.rst](https://github.com/qutip/qutip/blob/v5.2.0/doc/development/release_distribution.rst).

