### PR TITLE
New design for posts in overview

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -269,12 +269,20 @@ a.btn:focus {
   margin: auto;
 }
 
-.post-links>ul {
+.post .read-more {
+  margin-top: 25px;
+}
+
+.post-excerpt {
+  margin-top: 1rem;
+}
+
+.post-excerpt>ul {
   list-style-type: none;
   padding-left: 0;
 }
 
-.post-links>ul>li {
+.post-excerpt>ul>li {
   margin-bottom: 15px;
 }
 

--- a/news.html
+++ b/news.html
@@ -7,18 +7,16 @@ title: QuTiP News
 <hr>
 
 {% for p in site.posts %}
-    <div id="{{ p.slug }}" class="row" style='margin-bottom: 15px'>
-        <div class="col-md-8">
+    <div id="{{ p.slug }}" class="post row" style='margin-bottom: 15px'>
+        <div>
             <p>{{ p.date | date_to_string: "ordinal", "US" }}</p>
             <h4>{{ p.title }}</h4>
+            <div class="post-excerpt">
+                {{ p.excerpt }}
+            </div>
             {% if p.readmore %}
                 <a href="{{ p.url }}"><p>Read More</p></a>
             {% endif %}
-        </div>
-        <div class="col-md-4" style='margin-top: 25px'>
-            <div class="post-links">
-                {{ p.excerpt }}
-            </div>
         </div>
     </div>
 <hr>


### PR DESCRIPTION
Removed the sidebar for posts on the overview page.
Long text excerpts are thus shown more clearly.
An example picture of what that looks like is on Discord.